### PR TITLE
add custom property distribution in css/

### DIFF
--- a/config.json
+++ b/config.json
@@ -29,6 +29,20 @@
 				}
 			]
 		},
+		"customProperties": {
+			"transforms": [
+				"attribute/cti",
+				"name/cti/customProperty",
+				"color/optimizedRGBA"
+			],
+			"buildPath": "./dist/",
+			"files": [
+				{
+					"destination": "css/customProperties.scss",
+					"format": "css/customProperties"
+				}
+			]
+		},
 		"scss": {
 			"transforms": [
 				"attribute/cti",

--- a/config.json
+++ b/config.json
@@ -38,7 +38,7 @@
 			"buildPath": "./dist/",
 			"files": [
 				{
-					"destination": "css/customProperties.scss",
+					"destination": "css/customProperties.css",
 					"format": "css/customProperties"
 				}
 			]

--- a/scripts/formats.js
+++ b/scripts/formats.js
@@ -3,7 +3,7 @@
  * https://amzn.github.io/style-dictionary/formats_and_templates
  */
 
-const jsHeader = () =>
+const dateHeader = () =>
 	  '/**\n' +
 		' * Do not edit directly\n' +
 		' * Generated on ' + new Date() + '\n' +
@@ -11,15 +11,26 @@ const jsHeader = () =>
 
 const commonJS = {
 	name: 'javascript/commonJS',
-	formatter: (dictionary, platform) => jsHeader() + dictionary
+	formatter: (dictionary, platform) => dateHeader() + dictionary
 		.allProperties
 		.map(prop => `exports.${prop.name} = '${prop.value}';`)
 		.join('\n')
 };
 
+const customProperties = {
+	name: 'css/customProperties',
+	formatter: (dictionary, platform) => dateHeader() +
+		'\n:root {\n' +
+		dictionary
+			.allProperties
+			.map(p => `\t--${p.name}: ${p.value};`)
+			.join('\n') +
+		'\n}'
+};
+
 const colorAttributes = {
 	name: 'javascript/colorAttributes',
-	formatter: (dictionary, platform) => jsHeader() +
+	formatter: (dictionary, platform) => dateHeader() +
 		'module.exports = ' +
 			JSON.stringify(
 				dictionary
@@ -40,5 +51,6 @@ const colorAttributes = {
 
 module.exports = [
 	commonJS,
+	customProperties,
 	colorAttributes
 ];

--- a/scripts/transforms.js
+++ b/scripts/transforms.js
@@ -59,6 +59,20 @@ const prefixC = {
 		: `C_${prop.attributes.item}`
 };
 
+
+//
+// Name transform
+// converts "cti" object structure to css custom property `--[type]-[colorName]`
+//
+const customProperty = {
+	name: 'name/cti/customProperty',
+	type: 'name',
+	transformer: (prop, options) => prop.attributes.type === 'text' ?
+		`${prop.attributes.category}-text${capitalizeFirstLetter(prop.attributes.item)}`
+		: `${prop.attributes.category}-${prop.attributes.item}`
+};
+
+
 //
 // Name transform
 // converts "cti" object structure to valid js var `C_COLOR_NAME`
@@ -121,6 +135,7 @@ const colorVarNames = {
 module.exports = [
 	optimizedRGBA,
 	androidHex8,
+	customProperty,
 	prefixC,
 	jsConstant,
 	colorValues,


### PR DESCRIPTION
Add format and transforms to generate a dist in `css/customProperties.css` that looks like this:

```css
/**
 * Do not edit directly
 * Generated on Mon Jan 29 2018 15:06:41 GMT-0500 (EST)
 */


:root {
	--color-white: rgb(255, 255, 255);
	--color-lightGray: rgb(246, 247, 248);
	--color-mediumGray: rgb(117, 117, 117);
	--color-darkGray: rgb(53, 62, 72);
	--color-coolGrayLight: rgb(228, 233, 237);
	--color-coolGrayLightTransp: rgba(41, 77, 107, 0.12);
	--color-coolGrayMedium: rgb(151, 159, 164);
	--color-coolGrayMediumTransp: rgba(84, 96, 107, 0.6);
	--color-red: rgb(241, 58, 89);
	--color-darkRed: rgb(211, 45, 74);
	--color-pink: rgb(255, 153, 209);
...
}
```