### PR TITLE
Const 7/add cssvar to colorattributes

### DIFF
--- a/properties/responsive/space.json
+++ b/properties/responsive/space.json
@@ -2,7 +2,7 @@
 	"responsive": {
 		"space": {
 
-			"gutter": {
+			"1": {
 				"value": {
 					"default" : "16px",
 					"atMedium": "18px",

--- a/scripts/transforms.js
+++ b/scripts/transforms.js
@@ -75,8 +75,8 @@ const customProperty = {
 		} = prop.attributes;
 
 		const patterns = {
-			color: `--${c.slice(0,1)}-${i}`,
-			textColor: `--${c.slice(0,1)}-text${capitalizeFirstLetter(i)}`,
+			color: `--c-${i}`,
+			textColor: `--c-text${capitalizeFirstLetter(i)}`,
 			CTI: `--${c}-${t}-${i}`,
 			TI: `--${t}-${i}`,
 			CT: `--${c}-${t}`,

--- a/scripts/transforms.js
+++ b/scripts/transforms.js
@@ -68,45 +68,36 @@ const customProperty = {
 	name: 'name/cti/customProperty',
 	type: 'name',
 	transformer: (prop, options) => {
-		const category = prop.attributes.category;
-		const type = prop.attributes.type;
-		const item = prop.attributes.item;
+		const {
+			category: c,
+			type: t,
+			item: i,
+		} = prop.attributes;
 
-		const PATTERN_COLOR = `--${category.slice(0,1)}-${item}`;
-		const PATTERN_CTI = `--${category}-${type}-${item}`;
-		const PATTERN_CI = `--${category}-${item}`;
-		const PATTERN_CT = `--${category}-${type}`;
-		const PATTERN_TI = `--${type}-${item}`;
+		const patterns = {
+			color: `--${c.slice(0,1)}-${i}`,
+			textColor: `--${c.slice(0,1)}-text${capitalizeFirstLetter(i)}`,
+			CTI: `--${c}-${t}-${i}`,
+			TI: `--${t}-${i}`,
+			CT: `--${c}-${t}`,
+		};
 
-		// TODO: clean this up as we settle on naming conventions
-		switch(`${category}/${type}`) {
-			case 'color/base':
-				return PATTERN_COLOR;
-			case 'color/external':
-				return PATTERN_COLOR;
-			case 'color/ui':
-				return PATTERN_COLOR;
-			case 'color/text':
-				return `--${category.slice(0,1)}-text${capitalizeFirstLetter(item)}`;
-			case 'layout/breakpoint':
-				return PATTERN_TI;
-			case 'layout/width':
-				return PATTERN_TI;
-			case 'layout/radius':
-				return PATTERN_TI;
-			case 'layout/block':
-				return PATTERN_TI;
-			case 'layout/space':
-				return PATTERN_TI;
-			case 'layout/zindex':
-				return PATTERN_TI;
-			case 'responsive/media':
-				return PATTERN_TI;
-			case 'responsive/space':
-				return PATTERN_CT;
+		let name;
+		switch(c) {
+			case 'color':
+				name = (t === 'text') ? patterns.textColor : patterns.color
+				break;
+			case 'layout':
+				name = patterns.TI;
+				break;
+			case 'responsive':
+				name = (t === 'media') ? patterns.TI : patterns.CT;
+				break;
 			default:
-				return PATTERN_CTI;
+				name = patterns.CTI;
 		}
+
+		return name;
 	}
 };
 

--- a/scripts/transforms.js
+++ b/scripts/transforms.js
@@ -72,20 +72,22 @@ const customProperty = {
 		const type = prop.attributes.type;
 		const item = prop.attributes.item;
 
+		const PATTERN_COLOR = `--${category.slice(0,1)}-${item}`;
 		const PATTERN_CTI = `--${category}-${type}-${item}`;
 		const PATTERN_CI = `--${category}-${item}`;
+		const PATTERN_CT = `--${category}-${type}`;
 		const PATTERN_TI = `--${type}-${item}`;
 
 		// TODO: clean this up as we settle on naming conventions
 		switch(`${category}/${type}`) {
 			case 'color/base':
-				return PATTERN_CI;
+				return PATTERN_COLOR;
 			case 'color/external':
-				return PATTERN_CI;
+				return PATTERN_COLOR;
 			case 'color/ui':
-				return PATTERN_CI;
+				return PATTERN_COLOR;
 			case 'color/text':
-				return `--${category}-text${capitalizeFirstLetter(item)}`;
+				return `--${category.slice(0,1)}-text${capitalizeFirstLetter(item)}`;
 			case 'layout/breakpoint':
 				return PATTERN_TI;
 			case 'layout/width':
@@ -101,7 +103,7 @@ const customProperty = {
 			case 'responsive/media':
 				return PATTERN_TI;
 			case 'responsive/space':
-				return `--${item}`;
+				return PATTERN_CT;
 			default:
 				return PATTERN_CTI;
 		}

--- a/scripts/transforms.js
+++ b/scripts/transforms.js
@@ -153,7 +153,8 @@ const colorVarNames = {
 			colorVarNames: {
 				android: SD_transforms['name/cti/snake'].transformer(prop, options),
 				sass: `$${prefixC.transformer(prop)}`,
-				js: jsConstant.transformer(prop)
+				js: jsConstant.transformer(prop),
+				customProperty: customProperty.transformer(prop)
 			}
 		}
 	)


### PR DESCRIPTION
`Prelim` untijl #29 merges.

**example color in dist, `colorAttributes.js`:**
```js
   {
      "name": "white",
      "type": "base",
      "colorValues": {
         "rgba": "rgb(255, 255, 255)",
         "hex": "#ffffff",
         "hsv": "hsv(0, 0%, 100%)",
         "hsl": "hsl(0, 0%, 100%)",
         "androidHex8": "#ffffffff"
      },
      "colorVarNames": {
         "android": "color_base_white",
         "sass": "$C_white",
         "js": "C_WHITE",
         "customProperty": "--c-white"
      },
      "originalValue": [
         255,
         255,
         255,
         1
      ]
   },

```