### PR TITLE
Const 8/scss custom property dists

### DIFF
--- a/config.json
+++ b/config.json
@@ -43,7 +43,7 @@
 				}
 			]
 		},
-		"scssColors": {
+		"legacyScssColors": {
 			"transforms": [
 				"attribute/cti",
 				"name/cti/prefixC",
@@ -54,6 +54,22 @@
 				{
 					"destination": "scss/_colors.scss",
 					"format": "scss/colorVariables"
+				}
+			]
+		},
+		"scssCustomProperties": {
+			"transforms": [
+				"attribute/cti",
+				"attribute/colorValues",
+				"attribute/colorVarNames",
+				"name/cti/customProperty",
+				"color/optimizedRGBA"
+			],
+			"buildPath": "./dist/",
+			"files": [
+				{
+					"destination": "scss/_customProperties.scss",
+					"format": "scss/customProperties"
 				}
 			]
 		},

--- a/config.json
+++ b/config.json
@@ -57,6 +57,20 @@
 				}
 			]
 		},
+		"scssRawColors": {
+			"transforms": [
+				"attribute/cti",
+				"name/cti/prefixRaw",
+				"color/optimizedRGBA"
+			],
+			"buildPath": "./dist/",
+			"files": [
+				{
+					"destination": "scss/_rawColors.scss",
+					"format": "scss/colorVariables"
+				}
+			]
+		},
 		"scssCustomProperties": {
 			"transforms": [
 				"attribute/cti",

--- a/scripts/formats.js
+++ b/scripts/formats.js
@@ -153,11 +153,12 @@ const colorAttributes = {
 // variables for our Sass distributution
 const scssColorVariables = {
 	name: 'scss/colorVariables',
-	formatter: (dictionary) => SD_scssFormat(
-		dictionary
-			.allProperties
-			.filter(p => p.attributes.category === "color")
-	)
+	formatter: (dictionary, platform) => {
+		dictionary.allProperties = dictionary.allProperties
+			.filter(p => p.attributes.category === "color");
+
+		return SD_scssFormat(dictionary);
+	}
 };
 
 

--- a/scripts/formats.js
+++ b/scripts/formats.js
@@ -102,6 +102,23 @@ const customProperties = {
 	}
 };
 
+// SCSS Custom properties dist that includes mapping
+// legacy color vars to custom properties
+//
+const scssCustomProperties = {
+	name: 'scss/customProperties',
+	formatter: (dictionary) =>
+		customProperties.formatter(dictionary) +
+		'\n/* Map legacy Sass vars to custom properties */\n' +
+		dictionary
+			.allProperties
+			.filter(p => p.attributes.category === "color")
+			.map(p =>
+				`${p.attributes.colorVarNames.sass}: var(${p.attributes.colorVarNames.customProperty});`
+			)
+			.join('\n')
+};
+
 // Color attributes format (JS)
 // (!) "color" category only
 //
@@ -136,12 +153,11 @@ const colorAttributes = {
 // variables for our Sass distributution
 const scssColorVariables = {
 	name: 'scss/colorVariables',
-	formatter: (dictionary, platform) => {
-		dictionary.allProperties = dictionary.allProperties
-			.filter(p => p.attributes.category === "color");
-
-		return SD_scssFormat(dictionary);
-	}
+	formatter: (dictionary) => SD_scssFormat(
+		dictionary
+			.allProperties
+			.filter(p => p.attributes.category === "color")
+	)
 };
 
 
@@ -149,5 +165,6 @@ module.exports = [
 	commonJS,
 	customProperties,
 	colorAttributes,
-	scssColorVariables
+	scssColorVariables,
+	scssCustomProperties
 ];

--- a/scripts/transforms.js
+++ b/scripts/transforms.js
@@ -59,6 +59,21 @@ const prefixC = {
 		: `C_${prop.attributes.item}`
 };
 
+//
+// Name transform
+// converts "cti" object structure to sass `$RAW_[colorName]`
+// Enables users to make use of Sass or CSSNext polyfilled `color()`
+// function modification on a color.
+//
+const prefixRaw = {
+	name: 'name/cti/prefixRaw',
+	type: 'name',
+	matcher: prop => prop.attributes.category === 'color',
+	transformer: (prop, options) => prop.attributes.type === 'text' ?
+		`RAW_text${capitalizeFirstLetter(prop.attributes.item)}`
+		: `RAW_${prop.attributes.item}`
+};
+
 
 //
 // Name transform
@@ -167,6 +182,7 @@ module.exports = [
 	androidHex8,
 	customProperty,
 	prefixC,
+	prefixRaw,
 	jsConstant,
 	colorValues,
 	colorVarNames


### PR DESCRIPTION
Adds two new distributions for Sass:

- `_customProperties.scss`, which defines all custom properties and maps legacy sass colors vars to custom property values
- `_rawColors.scss`, which provides Sass vars that contain raw color values

The `_colors.scss` distribution will remain until all consumers are configured to only import the above dists (avoid breaking changes for now).

### custom properties dist
```
/**
 * Do not edit directly
 * Generated on Fri Feb 23 2018 18:39:46 GMT-0500 (EST)
 */


/* Default values */
:root {
	--c-white: rgb(255, 255, 255);
	--c-lightGray: rgb(246, 247, 248);
	--c-mediumGray: rgb(117, 117, 117);
	--c-darkGray: rgb(53, 62, 72);
	--c-coolGrayLight: rgb(228, 233, 237);
	--c-coolGrayLightTransp: rgba(41, 77, 107, 0.12);
	--c-coolGrayMedium: rgb(151, 159, 164);
	--c-coolGrayMediumTransp: rgba(84, 96, 107, 0.6);
	--c-red: rgb(241, 58, 89);
	--c-darkRed: rgb(211, 45, 74);
	--c-pink: rgb(255, 153, 209);
	--c-yellow: rgb(255, 229, 51);
	--c-lightBlue: rgb(77, 209, 237);
	--c-purple: rgb(55, 30, 172);
	--c-blue: rgb(0, 162, 199);
	--c-plum: rgb(112, 0, 176);
	--c-orange: rgb(255, 91, 15);
	--c-teal: rgb(0, 212, 128);
	--c-shamrock: rgb(89, 219, 51);
	--c-black: rgb(15, 23, 33);
	--c-facebook: rgb(59, 89, 152);
	--c-twitter: rgb(51, 204, 255);
	--c-linkedin: rgb(72, 117, 180);
	--c-tumblr: rgb(43, 73, 100);
	--c-flickr: rgb(254, 8, 131);
	--c-foursquare: rgb(12, 186, 223);
	--c-googleplus: rgb(198, 61, 45);
	--c-googleplusbutton: rgb(255, 255, 255);
	--c-instagram: rgb(78, 67, 60);
	--c-reddit: rgb(206, 227, 248);
	--c-wepay: rgb(72, 145, 220);
	--c-yahoo: rgb(123, 0, 153);
	--c-outlook: rgb(0, 114, 198);
	--c-textPrimary: rgb(46, 62, 72);
	--c-textSecondary: rgba(46, 62, 72, 0.6);
	--c-textTertiary: rgba(46, 62, 72, 0.35);
	--c-textHint: rgba(46, 62, 72, 0.35);
	--c-textDisabled: rgba(46, 62, 72, 0.12);
	--c-textPrimaryInverted: rgb(255, 255, 255);
	--c-textSecondaryInverted: rgba(255, 255, 255, 0.7);
	--c-textTertiaryInverted: rgba(255, 255, 255, 0.35);
	--c-textHintInverted: rgba(255, 255, 255, 0.35);
	--c-textDisabledInverted: rgba(255, 255, 255, 0.12);
	--c-attention: rgb(255, 91, 15);
	--c-success: rgb(0, 212, 128);
	--c-border: rgba(46, 62, 72, 0.12);
	--c-borderDark: rgba(46, 62, 72, 0.54);
	--c-borderInverted: rgba(255, 255, 255, 0.2);
	--c-borderDarkInverted: rgba(255, 255, 255, 0.7);
	--c-separator: rgba(46, 62, 72, 0.26);
	--c-highlight: rgba(0, 0, 255, 0.05);
	--c-selection: rgba(46, 62, 72, 0.05);
	--c-dimmingOverlay: rgba(46, 62, 72, 0.4);
	--c-tappable: rgba(56, 56, 15, 0.09);
	--c-tappableInverted: rgba(255, 246, 196, 0.27);
	--c-contentBG: rgb(255, 255, 255);
	--c-contentBGInverted: rgb(15, 23, 33);
	--c-collectionBG: rgb(246, 247, 248);
	--font-family-normal: 'Graphik Meetup', -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif;
	--font-family-mono: Monaco, 'Andale Mono', 'Courier New', monospace;
	--font-lineHeight-normal: 1.45;
	--font-lineHeight-largeText: 1.1;
	--font-lineHeight-smallText: 1.6;
	--font-lineHeight-runningText: 1.8;
	--font-size-tiny: 12px;
	--font-size-small: 14px;
	--font-size-normal: 16px;
	--font-size-big: 24px;
	--font-size-display3: 28px;
	--font-size-display2: 34px;
	--font-size-display1: 42px;
	--font-size-title: 32px;
	--font-weight-normal: 400;
	--font-weight-medium: 500;
	--font-weight-bold: 600;
	--block-1: 48px;
	--block-2: 72px;
	--block-3: 108px;
	--block-4: 160px;
	--block-5: 240px;
	--block-6: 384px;
	--block-7: 544px;
	--breakpoint-s: 440px;
	--breakpoint-m: 640px;
	--breakpoint-l: 840px;
	--breakpoint-xl: 1024px;
	--radius-small: 2px;
	--radius-normal: 4px;
	--radius-large: 8px;
	--space-1: 16px;
	--space-2: 24px;
	--space-3: 36px;
	--space-4: 56px;
	--space-5: 80px;
	--space-6: 120px;
	--space-7: 184px;
	--space-8: 280px;
	--space-half: 8px;
	--space-double: 32px;
	--space-quarter: 4px;
	--width-modal: 440px;
	--width-bounds: 840px;
	--width-bounds-wide: 1100px;
	--zindex-main: 0;
	--zindex-floatingContent: 10;
	--zindex-shade: 20;
	--zindex-shadeContent: 25;
	--zindex-modal: 30;
	--zindex-popup: 50;
	--media-xs: 16px;
	--media-s: 24px;
	--media-m: 36px;
	--media-l: 48px;
	--media-xl: 72px;
	--media-xxl: 120px;
	--responsive-space: 16px;
}

/* Medium breakpoint overrides */
@media only screen and (min-width: 640px) {
	:root {
		--media-xs: 18px;
		--media-s: 27px;
		--media-m: 40px;
		--media-l: 54px;
		--media-xl: 81px;
		--media-xxl: 135px;
		--responsive-space: 18px;
	}
}

/* Large breakpoint overrides */
@media only screen and (min-width: 840px) {
	:root {
		--media-xs: 20px;
		--media-s: 30px;
		--media-m: 45px;
		--media-l: 60px;
		--media-xl: 90px;
		--media-xxl: 150px;
		--responsive-space: 20px;
	}
}

/* Map legacy Sass vars to custom properties */
$C_white: var(--c-white);
$C_lightGray: var(--c-lightGray);
$C_mediumGray: var(--c-mediumGray);
$C_darkGray: var(--c-darkGray);
$C_coolGrayLight: var(--c-coolGrayLight);
$C_coolGrayLightTransp: var(--c-coolGrayLightTransp);
$C_coolGrayMedium: var(--c-coolGrayMedium);
$C_coolGrayMediumTransp: var(--c-coolGrayMediumTransp);
$C_red: var(--c-red);
$C_darkRed: var(--c-darkRed);
$C_pink: var(--c-pink);
$C_yellow: var(--c-yellow);
$C_lightBlue: var(--c-lightBlue);
$C_purple: var(--c-purple);
$C_blue: var(--c-blue);
$C_plum: var(--c-plum);
$C_orange: var(--c-orange);
$C_teal: var(--c-teal);
$C_shamrock: var(--c-shamrock);
$C_black: var(--c-black);
$C_facebook: var(--c-facebook);
$C_twitter: var(--c-twitter);
$C_linkedin: var(--c-linkedin);
$C_tumblr: var(--c-tumblr);
$C_flickr: var(--c-flickr);
$C_foursquare: var(--c-foursquare);
$C_googleplus: var(--c-googleplus);
$C_googleplusbutton: var(--c-googleplusbutton);
$C_instagram: var(--c-instagram);
$C_reddit: var(--c-reddit);
$C_wepay: var(--c-wepay);
$C_yahoo: var(--c-yahoo);
$C_outlook: var(--c-outlook);
$C_textPrimary: var(--c-textPrimary);
$C_textSecondary: var(--c-textSecondary);
$C_textTertiary: var(--c-textTertiary);
$C_textHint: var(--c-textHint);
$C_textDisabled: var(--c-textDisabled);
$C_textPrimaryInverted: var(--c-textPrimaryInverted);
$C_textSecondaryInverted: var(--c-textSecondaryInverted);
$C_textTertiaryInverted: var(--c-textTertiaryInverted);
$C_textHintInverted: var(--c-textHintInverted);
$C_textDisabledInverted: var(--c-textDisabledInverted);
$C_attention: var(--c-attention);
$C_success: var(--c-success);
$C_border: var(--c-border);
$C_borderDark: var(--c-borderDark);
$C_borderInverted: var(--c-borderInverted);
$C_borderDarkInverted: var(--c-borderDarkInverted);
$C_separator: var(--c-separator);
$C_highlight: var(--c-highlight);
$C_selection: var(--c-selection);
$C_dimmingOverlay: var(--c-dimmingOverlay);
$C_tappable: var(--c-tappable);
$C_tappableInverted: var(--c-tappableInverted);
$C_contentBG: var(--c-contentBG);
$C_contentBGInverted: var(--c-contentBGInverted);
$C_collectionBG: var(--c-collectionBG);
```

### raw colors dist
```
//
// Do not edit directly
// Generated on Fri Feb 23 2018 18:39:46 GMT-0500 (EST)
//

$RAW_white: rgb(255, 255, 255);
$RAW_lightGray: rgb(246, 247, 248);
$RAW_mediumGray: rgb(117, 117, 117);
$RAW_darkGray: rgb(53, 62, 72);
$RAW_coolGrayLight: rgb(228, 233, 237);
$RAW_coolGrayLightTransp: rgba(41, 77, 107, 0.12);
$RAW_coolGrayMedium: rgb(151, 159, 164);
$RAW_coolGrayMediumTransp: rgba(84, 96, 107, 0.6);
$RAW_red: rgb(241, 58, 89);
$RAW_darkRed: rgb(211, 45, 74);
$RAW_pink: rgb(255, 153, 209);
$RAW_yellow: rgb(255, 229, 51);
$RAW_lightBlue: rgb(77, 209, 237);
$RAW_purple: rgb(55, 30, 172);
$RAW_blue: rgb(0, 162, 199);
$RAW_plum: rgb(112, 0, 176);
$RAW_orange: rgb(255, 91, 15);
$RAW_teal: rgb(0, 212, 128);
$RAW_shamrock: rgb(89, 219, 51);
$RAW_black: rgb(15, 23, 33);
$RAW_facebook: rgb(59, 89, 152);
$RAW_twitter: rgb(51, 204, 255);
$RAW_linkedin: rgb(72, 117, 180);
$RAW_tumblr: rgb(43, 73, 100);
$RAW_flickr: rgb(254, 8, 131);
$RAW_foursquare: rgb(12, 186, 223);
$RAW_googleplus: rgb(198, 61, 45);
$RAW_googleplusbutton: rgb(255, 255, 255);
$RAW_instagram: rgb(78, 67, 60);
$RAW_reddit: rgb(206, 227, 248);
$RAW_wepay: rgb(72, 145, 220);
$RAW_yahoo: rgb(123, 0, 153);
$RAW_outlook: rgb(0, 114, 198);
$RAW_textPrimary: rgb(46, 62, 72);
$RAW_textSecondary: rgba(46, 62, 72, 0.6);
$RAW_textTertiary: rgba(46, 62, 72, 0.35);
$RAW_textHint: rgba(46, 62, 72, 0.35);
$RAW_textDisabled: rgba(46, 62, 72, 0.12);
$RAW_textPrimaryInverted: rgb(255, 255, 255);
$RAW_textSecondaryInverted: rgba(255, 255, 255, 0.7);
$RAW_textTertiaryInverted: rgba(255, 255, 255, 0.35);
$RAW_textHintInverted: rgba(255, 255, 255, 0.35);
$RAW_textDisabledInverted: rgba(255, 255, 255, 0.12);
$RAW_attention: rgb(255, 91, 15);
$RAW_success: rgb(0, 212, 128);
$RAW_border: rgba(46, 62, 72, 0.12);
$RAW_borderDark: rgba(46, 62, 72, 0.54);
$RAW_borderInverted: rgba(255, 255, 255, 0.2);
$RAW_borderDarkInverted: rgba(255, 255, 255, 0.7);
$RAW_separator: rgba(46, 62, 72, 0.26);
$RAW_highlight: rgba(0, 0, 255, 0.05);
$RAW_selection: rgba(46, 62, 72, 0.05);
$RAW_dimmingOverlay: rgba(46, 62, 72, 0.4);
$RAW_tappable: rgba(56, 56, 15, 0.09);
$RAW_tappableInverted: rgba(255, 246, 196, 0.27);
$RAW_contentBG: rgb(255, 255, 255);
$RAW_contentBGInverted: rgb(15, 23, 33);
$RAW_collectionBG: rgb(246, 247, 248);
```