### PR TITLE
rm scss dist of custom properties; add new scss vars dist

### DIFF
--- a/config.json
+++ b/config.json
@@ -57,10 +57,24 @@
 				}
 			]
 		},
+		"scssVariables": {
+			"transforms": [
+				"attribute/cti",
+				"name/cti/scssVar",
+				"color/optimizedRGBA"
+			],
+			"buildPath": "./dist/",
+			"files": [
+				{
+					"destination": "scss/_vars.scss",
+					"format": "scss/variablesCustom"
+				}
+			]
+		},
 		"legacyScssColors": {
 			"transforms": [
 				"attribute/cti",
-				"name/cti/prefixC",
+				"name/cti/scssVar",
 				"color/optimizedRGBA"
 			],
 			"buildPath": "./dist/",
@@ -68,36 +82,6 @@
 				{
 					"destination": "scss/_colors.scss",
 					"format": "scss/colorVariables"
-				}
-			]
-		},
-		"scssRawColors": {
-			"transforms": [
-				"attribute/cti",
-				"name/cti/prefixRaw",
-				"color/optimizedRGBA"
-			],
-			"buildPath": "./dist/",
-			"files": [
-				{
-					"destination": "scss/_rawColors.scss",
-					"format": "scss/colorVariables"
-				}
-			]
-		},
-		"scssCustomProperties": {
-			"transforms": [
-				"attribute/cti",
-				"attribute/colorValues",
-				"attribute/colorVarNames",
-				"name/cti/customProperty",
-				"color/optimizedRGBA"
-			],
-			"buildPath": "./dist/",
-			"files": [
-				{
-					"destination": "scss/_customProperties.scss",
-					"format": "scss/customProperties"
 				}
 			]
 		},

--- a/scripts/formats.js
+++ b/scripts/formats.js
@@ -102,23 +102,6 @@ const customProperties = {
 	}
 };
 
-// SCSS Custom properties dist that includes mapping
-// legacy color vars to custom properties
-//
-const scssCustomProperties = {
-	name: 'scss/customProperties',
-	formatter: (dictionary) =>
-		customProperties.formatter(dictionary) +
-		'\n/* Map legacy Sass vars to custom properties */\n' +
-		dictionary
-			.allProperties
-			.filter(p => p.attributes.category === "color")
-			.map(p =>
-				`${p.attributes.colorVarNames.sass}: var(${p.attributes.colorVarNames.customProperty});`
-			)
-			.join('\n')
-};
-
 // Color attributes format (JS)
 // (!) "color" category only
 //
@@ -146,6 +129,8 @@ const colorAttributes = {
 		';'
 };
 
+// DEPRECATED
+//
 // Sass color variables format (SCSS)
 // (!) "color" category only
 //
@@ -154,10 +139,26 @@ const colorAttributes = {
 const scssColorVariables = {
 	name: 'scss/colorVariables',
 	formatter: (dictionary, platform) => {
-		dictionary.allProperties = dictionary.allProperties
+		const allProperties = dictionary.allProperties
 			.filter(p => p.attributes.category === "color");
 
-		return SD_scssFormat(dictionary);
+		return SD_scssFormat({ allProperties });
+	}
+};
+
+// Sass variables format (SCSS)
+//
+// (!) does not emit items of "responsive" category
+//     as "responsive" items are handled in the custom
+//     properties CSS dist
+//
+const scssVariables = {
+	name: 'scss/variablesCustom',
+	formatter: (dictionary, platform) => {
+		const allProperties = dictionary.allProperties
+			.filter(p => p.attributes.category !== "responsive");
+
+		return SD_scssFormat({ allProperties });
 	}
 };
 
@@ -167,5 +168,5 @@ module.exports = [
 	customProperties,
 	colorAttributes,
 	scssColorVariables,
-	scssCustomProperties
+	scssVariables
 ];


### PR DESCRIPTION
- removed `dist/scss/_customProperties.scss` 
- added `dist/scss/_vars.scss`, which includes colors _and_ all other vars
- leaves legacy `dist/scss/_colors.scss` in place to avoid breaking change for now

**New dist (`_vars.scss`):**
This dist excludes the "responsive" category, as they require custom property magic to work.

```scss
//
// Do not edit directly
// Generated on Mon Mar 05 2018 16:59:00 GMT-0500 (EST)
//

$C_white: rgb(255, 255, 255);
$C_lightGray: rgb(246, 247, 248);
$C_mediumGray: rgb(117, 117, 117);
$C_darkGray: rgb(53, 62, 72);
$C_coolGrayLight: rgb(228, 233, 237);
$C_coolGrayLightTransp: rgba(41, 77, 107, 0.12);
$C_coolGrayMedium: rgb(151, 159, 164);
$C_coolGrayMediumTransp: rgba(84, 96, 107, 0.6);
$C_red: rgb(241, 58, 89);
$C_darkRed: rgb(211, 45, 74);
$C_pink: rgb(255, 153, 209);
$C_yellow: rgb(255, 229, 51);
$C_lightBlue: rgb(77, 209, 237);
$C_purple: rgb(55, 30, 172);
$C_blue: rgb(0, 162, 199);
$C_plum: rgb(112, 0, 176);
$C_orange: rgb(255, 91, 15);
$C_teal: rgb(0, 212, 128);
$C_shamrock: rgb(89, 219, 51);
$C_black: rgb(15, 23, 33);
$C_facebook: rgb(59, 89, 152);
$C_twitter: rgb(51, 204, 255);
$C_linkedin: rgb(72, 117, 180);
$C_tumblr: rgb(43, 73, 100);
$C_flickr: rgb(254, 8, 131);
$C_foursquare: rgb(12, 186, 223);
$C_googleplus: rgb(198, 61, 45);
$C_googleplusbutton: rgb(255, 255, 255);
$C_instagram: rgb(78, 67, 60);
$C_reddit: rgb(206, 227, 248);
$C_wepay: rgb(72, 145, 220);
$C_yahoo: rgb(123, 0, 153);
$C_outlook: rgb(0, 114, 198);
$C_textPrimary: rgb(46, 62, 72);
$C_textSecondary: rgba(46, 62, 72, 0.6);
$C_textTertiary: rgba(46, 62, 72, 0.35);
$C_textHint: rgba(46, 62, 72, 0.35);
$C_textDisabled: rgba(46, 62, 72, 0.12);
$C_textPrimaryInverted: rgb(255, 255, 255);
$C_textSecondaryInverted: rgba(255, 255, 255, 0.7);
$C_textTertiaryInverted: rgba(255, 255, 255, 0.35);
$C_textHintInverted: rgba(255, 255, 255, 0.35);
$C_textDisabledInverted: rgba(255, 255, 255, 0.12);
$C_attention: rgb(255, 91, 15);
$C_success: rgb(0, 212, 128);
$C_border: rgba(46, 62, 72, 0.12);
$C_borderDark: rgba(46, 62, 72, 0.54);
$C_borderInverted: rgba(255, 255, 255, 0.2);
$C_borderDarkInverted: rgba(255, 255, 255, 0.7);
$C_separator: rgba(46, 62, 72, 0.26);
$C_highlight: rgba(0, 0, 255, 0.05);
$C_selection: rgba(46, 62, 72, 0.05);
$C_dimmingOverlay: rgba(46, 62, 72, 0.4);
$C_tappable: rgba(56, 56, 15, 0.09);
$C_tappableInverted: rgba(255, 246, 196, 0.27);
$C_contentBG: rgb(255, 255, 255);
$C_contentBGInverted: rgb(15, 23, 33);
$C_collectionBG: rgb(246, 247, 248);
$font-family-normal: 'Graphik Meetup', -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif;
$font-family-mono: Monaco, 'Andale Mono', 'Courier New', monospace;
$font-lineHeight-normal: 1.45;
$font-lineHeight-largeText: 1.1;
$font-lineHeight-smallText: 1.6;
$font-lineHeight-runningText: 1.8;
$font-size-tiny: 12px;
$font-size-small: 14px;
$font-size-normal: 16px;
$font-size-big: 24px;
$font-size-display3: 28px;
$font-size-display2: 34px;
$font-size-display1: 42px;
$font-size-title: 32px;
$font-weight-normal: 400;
$font-weight-medium: 500;
$font-weight-bold: 600;
$block-1: 48px;
$block-2: 72px;
$block-3: 108px;
$block-4: 160px;
$block-5: 240px;
$block-6: 384px;
$block-7: 544px;
$breakpoint-s: 440px;
$breakpoint-m: 640px;
$breakpoint-l: 840px;
$breakpoint-xl: 1024px;
$radius-small: 2px;
$radius-normal: 4px;
$radius-large: 8px;
$space-1: 16px;
$space-2: 24px;
$space-3: 36px;
$space-4: 56px;
$space-5: 80px;
$space-6: 120px;
$space-7: 184px;
$space-8: 280px;
$space-half: 8px;
$space-double: 32px;
$space-quarter: 4px;
$width-modal: 440px;
$width-bounds: 840px;
$width-bounds-wide: 1100px;
$zindex-main: 0;
$zindex-floatingContent: 10;
$zindex-shade: 20;
$zindex-shadeContent: 25;
$zindex-modal: 30;
$zindex-popup: 50;
```