### PR TITLE
Const 13/mv custom props to module dist

### DIFF
--- a/config.json
+++ b/config.json
@@ -43,7 +43,7 @@
 				}
 			]
 		},
-		"customProperties": {
+		"CSSCustomProperties": {
 			"transforms": [
 				"attribute/cti",
 				"name/cti/customProperty",
@@ -54,6 +54,20 @@
 				{
 					"destination": "css/customProperties.css",
 					"format": "css/customProperties"
+				}
+			]
+		},
+		"SCSSModuleCustomProperties": {
+			"transforms": [
+				"attribute/cti",
+				"name/cti/customProperty",
+				"color/optimizedRGBA"
+			],
+			"buildPath": "./dist/",
+			"files": [
+				{
+					"destination": "scss/customProperties.module.scss",
+					"format": "cssModule/customProperties"
 				}
 			]
 		},

--- a/scripts/formats.js
+++ b/scripts/formats.js
@@ -29,10 +29,18 @@ const commonJS = {
 
 // CSS Custom properties format
 //
-const customProperties = {
+const customPropertiesCSS = {
 	name: 'css/customProperties',
 	formatter: (dictionary) =>
 		dateHeader() + customProperty.getAllCSSRules(dictionary, false)
+};
+
+// SCSS Module custom properties format
+//
+const customPropertiesCSSModule = {
+	name: 'cssModule/customProperties',
+	formatter: (dictionary) =>
+		dateHeader() + customProperty.getAllCSSRules(dictionary, true)
 };
 
 // Color attributes format (JS)
@@ -98,7 +106,8 @@ const scssVariables = {
 
 module.exports = [
 	commonJS,
-	customProperties,
+	customPropertiesCSS,
+	customPropertiesCSSModule,
 	colorAttributes,
 	scssColorVariables,
 	scssVariables

--- a/scripts/formats.js
+++ b/scripts/formats.js
@@ -1,24 +1,10 @@
-const fs = require('fs');
-const path = require('path');
 const SD_scssFormat = require('../node_modules/style-dictionary/lib/common/formats')['scss/variables'];
+const customProperty = require('./util/customProperty');
 
 /**
  * StyleDictionary custom formats
  * https://amzn.github.io/style-dictionary/formats_and_templates
  */
-
-// load and keep breakpoint values in memory
-// for responsive var value output
-const bpProperties = JSON.parse(
-		fs.readFileSync(
-			path.join(__dirname, '..', 'properties', 'layout', 'breakpoints.json')
-		)
-	);
-
-// get media query string from size keyword
-// (e.g. 's', 'm', 'l')
-const getMQBySize = (size) =>
-	`only screen and (min-width: ${bpProperties.layout.breakpoint[size].value})`;
 
 // generated content warning for top of files
 const dateHeader = () =>
@@ -43,63 +29,10 @@ const commonJS = {
 
 // CSS Custom properties format
 //
-// There is some extra complexity here due to support
-// for responsive custom properties. A "responsive"
-// custom property has a different value at medium
-// and large breakpoints. These properties are assigned
-// a default value in `:root` with overrides scoped
-// to media queries.
-//
-// A "standard" custom property has only one value,
-// and can be assigned in `:root` just once.
 const customProperties = {
 	name: 'css/customProperties',
-	formatter: (dictionary) => {
-		const { allProperties } = dictionary;
-		const lineTab = '\n\t';
-		const isResponsiveProp = (p) => p.path.includes('responsive');
-		const toCSSRule = (prop, size) => size ?
-			`${prop.name}: ${prop.value[size]};`
-			: `${prop.name}: ${prop.value};`;
-
-		return dateHeader() + `
-/* Default values */
-:root {
-	${allProperties
-		.filter(p => !isResponsiveProp(p))
-		.map(p => toCSSRule(p))
-		.join(lineTab)
-	}
-	${allProperties
-		.filter(p => isResponsiveProp(p))
-		.map(p => toCSSRule(p, 'default'))
-		.join(lineTab)
-	}
-}
-
-/* Medium breakpoint overrides */
-@media ${getMQBySize('m')} {
-	:root {
-		${allProperties
-			.filter(p => isResponsiveProp(p))
-			.map(p => toCSSRule(p, 'atMedium'))
-			.join(lineTab + '\t')
-		}
-	}
-}
-
-/* Large breakpoint overrides */
-@media ${getMQBySize('l')} {
-	:root {
-		${allProperties
-			.filter(p => isResponsiveProp(p))
-			.map(p => toCSSRule(p, 'atLarge'))
-			.join(lineTab + '\t')
-		}
-	}
-}
-`
-	}
+	formatter: (dictionary) =>
+		dateHeader() + customProperty.getAllCSSRules(dictionary, false)
 };
 
 // Color attributes format (JS)

--- a/scripts/util/customProperty.js
+++ b/scripts/util/customProperty.js
@@ -1,0 +1,93 @@
+const fs = require('fs');
+const path = require('path');
+
+// load and keep breakpoint values in memory
+// for responsive var value output
+const bpProperties = JSON.parse(
+		fs.readFileSync(
+			path.join(__dirname, '..', '..', 'properties', 'layout', 'breakpoints.json')
+		)
+	);
+
+/**
+ * @function getMQBySize
+ *
+ * @param {String} size - breakpoint shorthand size (e.g. 's', 'm', 'l')
+ * @returns {String} - full media query string
+ */
+const getMQBySize = (size) =>
+	`only screen and (min-width: ${bpProperties.layout.breakpoint[size].value})`;
+
+/**
+ * @function getRootSelector
+ *
+ * @param {Boolean} isModule - flag for CSS Modules
+ * @returns {String} - CSS seletor for root element (specificed as global for modules)
+ */
+const getRootSelector = (isModule) => isModule ?
+	':global :root'
+	: ':root';
+
+module.exports = {
+
+	/**
+	 * @funciton getAllCSSRules
+	 * gets full string of CSS rules for defining custom properties
+	 *
+	 * There is some extra complexity here due to support
+	 * for responsive custom properties. A "responsive"
+	 * custom property has a different value at medium
+	 * and large breakpoints. These properties are assigned
+	 * a default value in `:root` with overrides scoped
+	 * to media queries.
+	 *
+	 * @param {Object} dictionary - the style dictionary
+	 * @param {Boolean} isModule - flag to use `:global` for CSS Modules
+	 */
+	getAllCSSRules: (dictionary, isModule) => {
+		const { allProperties } = dictionary;
+		const lineTab = '\n\t';
+		const isResponsiveProp = (p) => p.path.includes('responsive');
+		const toCSSRule = (prop, size) => size ?
+			`${prop.name}: ${prop.value[size]};`
+			: `${prop.name}: ${prop.value};`;
+
+		return `
+/* Default values */
+${getRootSelector(isModule)} {
+	${allProperties
+		.filter(p => !isResponsiveProp(p))
+		.map(p => toCSSRule(p))
+		.join(lineTab)
+	}
+	${allProperties
+		.filter(p => isResponsiveProp(p))
+		.map(p => toCSSRule(p, 'default'))
+		.join(lineTab)
+	}
+}
+
+/* Medium breakpoint overrides */
+@media ${getMQBySize('m')} {
+	${getRootSelector(isModule)} {
+		${allProperties
+			.filter(p => isResponsiveProp(p))
+			.map(p => toCSSRule(p, 'atMedium'))
+			.join(lineTab + '\t')
+		}
+	}
+}
+
+/* Large breakpoint overrides */
+@media ${getMQBySize('l')} {
+	${getRootSelector(isModule)} {
+		${allProperties
+			.filter(p => isResponsiveProp(p))
+			.map(p => toCSSRule(p, 'atLarge'))
+			.join(lineTab + '\t')
+		}
+	}
+}
+`;
+	}
+};


### PR DESCRIPTION
- Refactors custom properties format as a utility to allow passing a flag for CSS Modules
- add scss module dist

### CSS dist
```css
/**
 * Do not edit directly
 * Generated on Wed Mar 07 2018 15:51:15 GMT-0500 (EST)
 */


/* Default values */
:root {
	--c-white: rgb(255, 255, 255);
	--c-lightGray: rgb(246, 247, 248);
	--c-mediumGray: rgb(117, 117, 117);
	--c-darkGray: rgb(53, 62, 72);
	--c-coolGrayLight: rgb(228, 233, 237);
	--c-coolGrayLightTransp: rgba(41, 77, 107, 0.12);
	--c-coolGrayMedium: rgb(151, 159, 164);
	--c-coolGrayMediumTransp: rgba(84, 96, 107, 0.6);
	--c-red: rgb(241, 58, 89);
	--c-darkRed: rgb(211, 45, 74);
	--c-pink: rgb(255, 153, 209);
	--c-yellow: rgb(255, 229, 51);
	--c-lightBlue: rgb(77, 209, 237);
	--c-purple: rgb(55, 30, 172);
	--c-blue: rgb(0, 162, 199);
	--c-plum: rgb(112, 0, 176);
	--c-orange: rgb(255, 91, 15);
	--c-teal: rgb(0, 212, 128);
	--c-shamrock: rgb(89, 219, 51);
	--c-black: rgb(15, 23, 33);
	--c-facebook: rgb(59, 89, 152);
	--c-twitter: rgb(51, 204, 255);
	--c-linkedin: rgb(72, 117, 180);
	--c-tumblr: rgb(43, 73, 100);
	--c-flickr: rgb(254, 8, 131);
	--c-foursquare: rgb(12, 186, 223);
	--c-googleplus: rgb(198, 61, 45);
	--c-googleplusbutton: rgb(255, 255, 255);
	--c-instagram: rgb(78, 67, 60);
	--c-reddit: rgb(206, 227, 248);
	--c-wepay: rgb(72, 145, 220);
	--c-yahoo: rgb(123, 0, 153);
	--c-outlook: rgb(0, 114, 198);
	--c-textPrimary: rgb(46, 62, 72);
	--c-textSecondary: rgba(46, 62, 72, 0.6);
	--c-textTertiary: rgba(46, 62, 72, 0.35);
	--c-textHint: rgba(46, 62, 72, 0.35);
	--c-textDisabled: rgba(46, 62, 72, 0.12);
	--c-textPrimaryInverted: rgb(255, 255, 255);
	--c-textSecondaryInverted: rgba(255, 255, 255, 0.7);
	--c-textTertiaryInverted: rgba(255, 255, 255, 0.35);
	--c-textHintInverted: rgba(255, 255, 255, 0.35);
	--c-textDisabledInverted: rgba(255, 255, 255, 0.12);
	--c-attention: rgb(255, 91, 15);
	--c-success: rgb(0, 212, 128);
	--c-border: rgba(46, 62, 72, 0.12);
	--c-borderDark: rgba(46, 62, 72, 0.54);
	--c-borderInverted: rgba(255, 255, 255, 0.2);
	--c-borderDarkInverted: rgba(255, 255, 255, 0.7);
	--c-separator: rgba(46, 62, 72, 0.26);
	--c-highlight: rgba(0, 0, 255, 0.05);
	--c-selection: rgba(46, 62, 72, 0.05);
	--c-dimmingOverlay: rgba(46, 62, 72, 0.4);
	--c-tappable: rgba(56, 56, 15, 0.09);
	--c-tappableInverted: rgba(255, 246, 196, 0.27);
	--c-contentBG: rgb(255, 255, 255);
	--c-contentBGInverted: rgb(15, 23, 33);
	--c-collectionBG: rgb(246, 247, 248);
	--font-family-normal: 'Graphik Meetup', -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif;
	--font-family-mono: Monaco, 'Andale Mono', 'Courier New', monospace;
	--font-lineHeight-normal: 1.45;
	--font-lineHeight-largeText: 1.1;
	--font-lineHeight-smallText: 1.6;
	--font-lineHeight-runningText: 1.8;
	--font-size-tiny: 12px;
	--font-size-small: 14px;
	--font-size-normal: 16px;
	--font-size-big: 24px;
	--font-size-display3: 28px;
	--font-size-display2: 34px;
	--font-size-display1: 42px;
	--font-size-title: 32px;
	--font-weight-normal: 400;
	--font-weight-medium: 500;
	--font-weight-bold: 600;
	--block-1: 48px;
	--block-2: 72px;
	--block-3: 108px;
	--block-4: 160px;
	--block-5: 240px;
	--block-6: 384px;
	--block-7: 544px;
	--breakpoint-s: 440px;
	--breakpoint-m: 640px;
	--breakpoint-l: 840px;
	--breakpoint-xl: 1024px;
	--radius-small: 2px;
	--radius-normal: 4px;
	--radius-large: 8px;
	--space-1: 16px;
	--space-2: 24px;
	--space-3: 36px;
	--space-4: 56px;
	--space-5: 80px;
	--space-6: 120px;
	--space-7: 184px;
	--space-8: 280px;
	--space-half: 8px;
	--space-double: 32px;
	--space-quarter: 4px;
	--width-modal: 440px;
	--width-bounds: 840px;
	--width-bounds-wide: 1100px;
	--zindex-main: 0;
	--zindex-floatingContent: 10;
	--zindex-shade: 20;
	--zindex-shadeContent: 25;
	--zindex-modal: 30;
	--zindex-popup: 50;
	--media-xs: 16px;
	--media-s: 24px;
	--media-m: 36px;
	--media-l: 48px;
	--media-xl: 72px;
	--media-xxl: 120px;
	--responsive-space: 16px;
}

/* Medium breakpoint overrides */
@media only screen and (min-width: 640px) {
	:root {
		--media-xs: 18px;
		--media-s: 27px;
		--media-m: 40px;
		--media-l: 54px;
		--media-xl: 81px;
		--media-xxl: 135px;
		--responsive-space: 18px;
	}
}

/* Large breakpoint overrides */
@media only screen and (min-width: 840px) {
	:root {
		--media-xs: 20px;
		--media-s: 30px;
		--media-m: 45px;
		--media-l: 60px;
		--media-xl: 90px;
		--media-xxl: 150px;
		--responsive-space: 20px;
	}
}
```

### CSS Module dist
```css
/**
 * Do not edit directly
 * Generated on Wed Mar 07 2018 15:51:15 GMT-0500 (EST)
 */


/* Default values */
:global :root {
	--c-white: rgb(255, 255, 255);
	--c-lightGray: rgb(246, 247, 248);
	--c-mediumGray: rgb(117, 117, 117);
	--c-darkGray: rgb(53, 62, 72);
	--c-coolGrayLight: rgb(228, 233, 237);
	--c-coolGrayLightTransp: rgba(41, 77, 107, 0.12);
	--c-coolGrayMedium: rgb(151, 159, 164);
	--c-coolGrayMediumTransp: rgba(84, 96, 107, 0.6);
	--c-red: rgb(241, 58, 89);
	--c-darkRed: rgb(211, 45, 74);
	--c-pink: rgb(255, 153, 209);
	--c-yellow: rgb(255, 229, 51);
	--c-lightBlue: rgb(77, 209, 237);
	--c-purple: rgb(55, 30, 172);
	--c-blue: rgb(0, 162, 199);
	--c-plum: rgb(112, 0, 176);
	--c-orange: rgb(255, 91, 15);
	--c-teal: rgb(0, 212, 128);
	--c-shamrock: rgb(89, 219, 51);
	--c-black: rgb(15, 23, 33);
	--c-facebook: rgb(59, 89, 152);
	--c-twitter: rgb(51, 204, 255);
	--c-linkedin: rgb(72, 117, 180);
	--c-tumblr: rgb(43, 73, 100);
	--c-flickr: rgb(254, 8, 131);
	--c-foursquare: rgb(12, 186, 223);
	--c-googleplus: rgb(198, 61, 45);
	--c-googleplusbutton: rgb(255, 255, 255);
	--c-instagram: rgb(78, 67, 60);
	--c-reddit: rgb(206, 227, 248);
	--c-wepay: rgb(72, 145, 220);
	--c-yahoo: rgb(123, 0, 153);
	--c-outlook: rgb(0, 114, 198);
	--c-textPrimary: rgb(46, 62, 72);
	--c-textSecondary: rgba(46, 62, 72, 0.6);
	--c-textTertiary: rgba(46, 62, 72, 0.35);
	--c-textHint: rgba(46, 62, 72, 0.35);
	--c-textDisabled: rgba(46, 62, 72, 0.12);
	--c-textPrimaryInverted: rgb(255, 255, 255);
	--c-textSecondaryInverted: rgba(255, 255, 255, 0.7);
	--c-textTertiaryInverted: rgba(255, 255, 255, 0.35);
	--c-textHintInverted: rgba(255, 255, 255, 0.35);
	--c-textDisabledInverted: rgba(255, 255, 255, 0.12);
	--c-attention: rgb(255, 91, 15);
	--c-success: rgb(0, 212, 128);
	--c-border: rgba(46, 62, 72, 0.12);
	--c-borderDark: rgba(46, 62, 72, 0.54);
	--c-borderInverted: rgba(255, 255, 255, 0.2);
	--c-borderDarkInverted: rgba(255, 255, 255, 0.7);
	--c-separator: rgba(46, 62, 72, 0.26);
	--c-highlight: rgba(0, 0, 255, 0.05);
	--c-selection: rgba(46, 62, 72, 0.05);
	--c-dimmingOverlay: rgba(46, 62, 72, 0.4);
	--c-tappable: rgba(56, 56, 15, 0.09);
	--c-tappableInverted: rgba(255, 246, 196, 0.27);
	--c-contentBG: rgb(255, 255, 255);
	--c-contentBGInverted: rgb(15, 23, 33);
	--c-collectionBG: rgb(246, 247, 248);
	--font-family-normal: 'Graphik Meetup', -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif;
	--font-family-mono: Monaco, 'Andale Mono', 'Courier New', monospace;
	--font-lineHeight-normal: 1.45;
	--font-lineHeight-largeText: 1.1;
	--font-lineHeight-smallText: 1.6;
	--font-lineHeight-runningText: 1.8;
	--font-size-tiny: 12px;
	--font-size-small: 14px;
	--font-size-normal: 16px;
	--font-size-big: 24px;
	--font-size-display3: 28px;
	--font-size-display2: 34px;
	--font-size-display1: 42px;
	--font-size-title: 32px;
	--font-weight-normal: 400;
	--font-weight-medium: 500;
	--font-weight-bold: 600;
	--block-1: 48px;
	--block-2: 72px;
	--block-3: 108px;
	--block-4: 160px;
	--block-5: 240px;
	--block-6: 384px;
	--block-7: 544px;
	--breakpoint-s: 440px;
	--breakpoint-m: 640px;
	--breakpoint-l: 840px;
	--breakpoint-xl: 1024px;
	--radius-small: 2px;
	--radius-normal: 4px;
	--radius-large: 8px;
	--space-1: 16px;
	--space-2: 24px;
	--space-3: 36px;
	--space-4: 56px;
	--space-5: 80px;
	--space-6: 120px;
	--space-7: 184px;
	--space-8: 280px;
	--space-half: 8px;
	--space-double: 32px;
	--space-quarter: 4px;
	--width-modal: 440px;
	--width-bounds: 840px;
	--width-bounds-wide: 1100px;
	--zindex-main: 0;
	--zindex-floatingContent: 10;
	--zindex-shade: 20;
	--zindex-shadeContent: 25;
	--zindex-modal: 30;
	--zindex-popup: 50;
	--media-xs: 16px;
	--media-s: 24px;
	--media-m: 36px;
	--media-l: 48px;
	--media-xl: 72px;
	--media-xxl: 120px;
	--responsive-space: 16px;
}

/* Medium breakpoint overrides */
@media only screen and (min-width: 640px) {
	:global :root {
		--media-xs: 18px;
		--media-s: 27px;
		--media-m: 40px;
		--media-l: 54px;
		--media-xl: 81px;
		--media-xxl: 135px;
		--responsive-space: 18px;
	}
}

/* Large breakpoint overrides */
@media only screen and (min-width: 840px) {
	:global :root {
		--media-xs: 20px;
		--media-s: 30px;
		--media-m: 45px;
		--media-l: 60px;
		--media-xl: 90px;
		--media-xxl: 150px;
		--responsive-space: 20px;
	}
}
```