### PR TITLE
add importable style module dist of full custom properties

### DIFF
--- a/config.json
+++ b/config.json
@@ -43,6 +43,20 @@
 				}
 			]
 		},
+		"ScssModuleCustomProperties": {
+			"transforms": [
+				"attribute/cti",
+				"name/cti/customProperty",
+				"color/optimizedRGBA"
+			],
+			"buildPath": "./dist/",
+			"files": [
+				{
+					"destination": "scss/customProperties.module.scss",
+					"format": "css/customProperties"
+				}
+			]
+		},
 		"CSSCustomProperties": {
 			"transforms": [
 				"attribute/cti",


### PR DESCRIPTION
This dist enables us to import CSS custom properties as a module in either `Dom.jsx` in `meetup-web-platform`, or in root-level app components. Importing custom property definitions as a module makes the definitions visible to `postcss-loader`, which polyfills custom properties for IE11.