### PR TITLE
Added sectionTitle font size

### DIFF
--- a/properties/font/size.json
+++ b/properties/font/size.json
@@ -11,6 +11,9 @@
 			"normal": {
 				"value": "16px"
 			},
+			"sectionTitle": {
+				"value": "20px"
+			},
 			"big": {
 				"value": "24px"
 			},


### PR DESCRIPTION
We currently have a sass variable, `$font-size-big2` used for the size of section titles [being set in swarm-sasstools](https://github.com/meetup/swarm-sasstools/blob/master/scss/utils/vars/_type.scss#L26), but this never made it into constants