### PR TITLE
Fix JS constants

### DIFF
--- a/config.json
+++ b/config.json
@@ -33,7 +33,8 @@
 			"transforms": [
 				"attribute/cti",
 				"name/cti/jsConstant",
-				"color/optimizedRGBA"
+				"color/optimizedRGBA",
+				"value/fontNameJS"
 			],
 			"buildPath": "./dist/",
 			"files": [

--- a/scripts/transforms.js
+++ b/scripts/transforms.js
@@ -110,13 +110,13 @@ const androidHex8 = {
 
 
 //
-// Color transform
-// converts color to optimized rgb/rgba
+// Font name transform for JS
+// converts values in the `font` category that contain single quotes to use double quotes
 //
 const fontNameJS = {
 	name: 'value/fontNameJS',
-	matcher: prop => prop.attributes.category === 'font',
 	type: 'value',
+	matcher: prop => prop.attributes.category === 'font',
 	transformer: (prop, options) => {
 		return prop.original.value.replace(/'/g,'\"');
 	}
@@ -182,8 +182,6 @@ const jsConstant = {
 		// JS constants should be all upper case
 		Object.keys(propNames)
 			.forEach(k => propNames[k] = propNames[k].toUpperCase().replace(/-/g, '_'));
-
-		// console.dir(propNames);
 
 		return getNameWithWebConvention(prop, propNames);
 	}

--- a/scripts/transforms.js
+++ b/scripts/transforms.js
@@ -109,6 +109,18 @@ const androidHex8 = {
 };
 
 
+//
+// Color transform
+// converts color to optimized rgb/rgba
+//
+const fontNameJS = {
+	name: 'value/fontNameJS',
+	matcher: prop => prop.attributes.category === 'font',
+	type: 'value',
+	transformer: (prop, options) => {
+		return prop.original.value.replace(/'/g,'\"');
+	}
+};
 
 
 //
@@ -169,9 +181,9 @@ const jsConstant = {
 
 		// JS constants should be all upper case
 		Object.keys(propNames)
-			.forEach(k => propNames[k] = propNames[k].toUpperCase());
+			.forEach(k => propNames[k] = propNames[k].toUpperCase().replace(/-/g, '_'));
 
-		console.dir(propNames);
+		// console.dir(propNames);
 
 		return getNameWithWebConvention(prop, propNames);
 	}
@@ -228,6 +240,7 @@ const colorVarNames = {
 module.exports = [
 	optimizedRGBA,
 	androidHex8,
+	fontNameJS,
 	customProperty,
 	scssVar,
 	jsConstant,

--- a/scripts/transforms.js
+++ b/scripts/transforms.js
@@ -179,7 +179,7 @@ const jsConstant = {
 			textDelimiter: '_',
 		});
 
-		// JS constants should be all upper case
+		// JS constants should be all upper case with an underscore separator
 		Object.keys(propNames)
 			.forEach(k => propNames[k] = propNames[k].toUpperCase().replace(/-/g, '_'));
 


### PR DESCRIPTION
After running `yarn build`, `dist/js/constants.js` had the following problems:

1: Lines needed to handle inner string quotes for JS:
```
exports.FONT_FAMILY_NORMAL = ''Graphik Meetup', -apple-system, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif';
exports.FONT_FAMILY_MONO = 'Monaco, 'Andale Mono', 'Courier New', monospace';
```

2: This line has a key with a hyphen in it:
```
exports.WIDTH_BOUNDS-WIDE = '1100px';
```

I updated the transforms to handle these issues